### PR TITLE
Implement category edit/delete

### DIFF
--- a/Fronts/ControlPanel/src/Context/ContextHooks/useModal.tsx
+++ b/Fronts/ControlPanel/src/Context/ContextHooks/useModal.tsx
@@ -32,7 +32,8 @@ function useModal() {
   })
   const [categoriesModal, setCategoriesModal] = useState<CategoriesModal>({
     formType: "create",
-    opened: false
+    opened: false,
+    editCategoryData: null
   })
 
   const closeBusinessModal = () => {
@@ -68,7 +69,8 @@ function useModal() {
   const closeCategoriesModal = () => {
     setCategoriesModal({
       formType: "create",
-      opened: false
+      opened: false,
+      editCategoryData: null
     })
   }
   return useMemo(() => ({

--- a/Fronts/ControlPanel/src/Context/ContextTypes.ts
+++ b/Fronts/ControlPanel/src/Context/ContextTypes.ts
@@ -37,7 +37,8 @@ interface CategoriesHooks{
     categories: Category[],
     saveCategory: (formData: CategoriesForm, fileData: File) => Promise<boolean>
     retrieveCategories: (bsd_id: string) => Promise<boolean>,
-    
+    updateCategory: (formData: CategoriesForm, fileData: File, category_id: string) => Promise<boolean>,
+    deleteCategory: (category_id: string) => Promise<boolean>
 }
 
 export interface AppContextTypes{

--- a/Fronts/ControlPanel/src/Context/HookTypes/Categories.ts
+++ b/Fronts/ControlPanel/src/Context/HookTypes/Categories.ts
@@ -1,6 +1,7 @@
 export interface CategoriesModal{
     opened: boolean,
-    formType?: "edit" | "create"
+    formType?: "edit" | "create",
+    editCategoryData?: Category | null
 }
 
 export interface CategoriesForm{

--- a/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Form/CategoryForm.tsx
+++ b/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Form/CategoryForm.tsx
@@ -4,6 +4,7 @@ import FormFields from './components/FormFields';
 import ImageSection from './components/ImageSection';
 import PexelsGallery from './components/PexelsGallery';
 import useCategoryForm from './Hooks/useCategoryForm';
+import { useAppContext } from '../../../../Context/AppContext';
 
 function CategoryForm() {
   const {
@@ -25,14 +26,16 @@ function CategoryForm() {
     retryPexelsSearch,
     pexelsSearchTerm,
     setPexelsSearchTerm,
-    clearImage
+    clearImage,
+    fetchingImageToEdit
   } = useCategoryForm();
+  const { useModalHook:{ categoriesModal } } = useAppContext()
 
   if (formSuccess) {
     return (
       <Paper withBorder p="md" radius="md" style={{ maxWidth: 600, margin: '0 auto' }}>
         <Flex direction="column" align="center" justify="center" gap="md">
-          <Text size="lg" fw={500}>🎉 Categoría guardada exitosamente.</Text>
+          <Text size="lg" fw={500}>🎉 {categoriesModal?.formType === 'create' ? 'Categoría guardada exitosamente.' : 'Categoría actualizada exitosamente.'}</Text>
         </Flex>
       </Paper>
     );
@@ -51,6 +54,7 @@ function CategoryForm() {
           fileData={fileData}
           processingFile={processingFile}
           searchingPexels={searchingPexels}
+          fetchingImage={fetchingImageToEdit}
           formData={formData}
           usePexelsImage={usePexelsImage}
           onFileUpload={handleUpload}
@@ -72,11 +76,11 @@ function CategoryForm() {
         <Button
           type="submit"
           loading={formLoading}
-          disabled={formLoading || processingFile || searchingPexels}
+          disabled={formLoading || processingFile || searchingPexels || fetchingImageToEdit}
           fullWidth
           mt="md"
         >
-          Guardar Categoría
+          {categoriesModal?.formType === 'create' ? 'Guardar Categoría' : 'Actualizar Categoría'}
         </Button>
       </Flex>
     </form>

--- a/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Form/components/ImageSection.tsx
+++ b/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Form/components/ImageSection.tsx
@@ -7,6 +7,7 @@ interface ImageSectionProps {
   fileData: File | null;
   processingFile: boolean;
   searchingPexels: boolean;
+  fetchingImage?: boolean;
   formData: { category_name: string };
   usePexelsImage: boolean;
   onFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -21,6 +22,7 @@ function ImageSection({
   fileData,
   processingFile,
   searchingPexels,
+  fetchingImage = false,
   formData,
   onFileUpload,
   onUsePexelsImage,
@@ -32,7 +34,7 @@ function ImageSection({
   const createPreviewUrl = (file: File | Blob) => URL.createObjectURL(file);
 
   if (!fileData) {
-    if (processingFile || searchingPexels) {
+    if (processingFile || searchingPexels || fetchingImage) {
       return (
         <div className="processing-file-container">
           <div className="loader" />

--- a/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Table/CategoriesCardList.tsx
+++ b/Fronts/ControlPanel/src/Pages/MenuConfig/components/Categories/components/Table/CategoriesCardList.tsx
@@ -8,10 +8,14 @@ function CategoriesCardList() {
   const {
     categoriesHooks:{
       categories,
-      retrieveCategories
+      retrieveCategories,
+      deleteCategory
     },
-    businessHooks:{ 
+    businessHooks:{
       businessData
+    },
+    useModalHook:{
+      setCategoriesModal
     }
   } = useAppContext()
   
@@ -82,6 +86,7 @@ function CategoriesCardList() {
               variant="light"
               color="blue"
               leftSection={<FaEdit size={16} />}
+              onClick={() => setCategoriesModal({opened: true, formType: 'edit', editCategoryData: cat})}
             >
               Editar
             </Button>
@@ -90,6 +95,7 @@ function CategoriesCardList() {
               variant="light"
               color="red"
               leftSection={<FaTrash size={16} />}
+              onClick={() => deleteCategory(cat.category_id || cat.category_name)}
             >
               Eliminar
             </Button>

--- a/server/app/routes/categories_routes.py
+++ b/server/app/routes/categories_routes.py
@@ -1,5 +1,10 @@
 from flask import Blueprint, request, jsonify
-from app.services.Categories.categories_services import save_category, get_categories
+from app.services.Categories.categories_services import (
+    save_category,
+    get_categories,
+    update_category,
+    delete_category
+)
 from app.validations.CategoriesTypes import CategoryPayload
 categories_routes = Blueprint("categories_routes", __name__)
 
@@ -44,4 +49,46 @@ def get_categories_route():
     
     result = get_categories(business_id)
 
+    return result
+
+
+@categories_routes.route("/update", methods=["PUT"])
+def update_category_route():
+    business_id = request.args.get("business_id")
+    category_id = request.args.get("category_id")
+    if not business_id or not category_id:
+        return jsonify({"message": "business_id y category_id son requeridos"}), 400
+
+    try:
+        required_fields = {
+            "category_name": request.form.get("category_name"),
+            "category_description": request.form.get("category_description"),
+            "category_image": request.files.get("category_image")
+        }
+
+        for fname, fvalue in required_fields.items():
+            if fvalue is None:
+                return jsonify({"message": f"Campo requerido faltante: {fname}"}), 400
+
+        category_data: CategoryPayload = {
+            "category_name": required_fields["category_name"],
+            "category_description": required_fields["category_description"],
+            "business_id": business_id,
+            "category_image": required_fields["category_image"]
+        }
+    except Exception as e:
+        return jsonify({"message": f"Error al procesar los datos del formulario: {str(e)}"}), 400
+
+    result = update_category(category_data, category_id, business_id)
+    return result
+
+
+@categories_routes.route("/delete", methods=["DELETE"])
+def delete_category_route():
+    business_id = request.args.get("business_id")
+    category_id = request.args.get("category_id")
+    if not business_id or not category_id:
+        return jsonify({"message": "business_id y category_id son requeridos"}), 400
+
+    result = delete_category(category_id, business_id)
     return result


### PR DESCRIPTION
## Summary
- add update and delete logic to backend service and routes
- extend category context and hooks for update/delete
- support editing state in modal hooks and forms
- add image loader for category editing
- enable category edit & remove actions in card list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855c62ab5fc832d8748c1bd9725e9fb